### PR TITLE
Add acceptExitCodes to builders.

### DIFF
--- a/Fun.Build.Tests/ConditionsBuilderTests.fs
+++ b/Fun.Build.Tests/ConditionsBuilderTests.fs
@@ -203,3 +203,30 @@ let ``when compose should work`` () =
     }
     |> condition.Invoke
     |> Assert.False
+
+[<Fact>]
+let ``acceptExitCodes should override exit codes in pipeline`` () =
+    let pipeline =
+        pipeline "main" {
+            acceptExitCodes [| 1;2;3 |]
+        }
+
+    let codes = pipeline.AcceptableExitCodes |> Seq.toArray
+    Assert.Equal<int array>([| 1;2;3 |], codes)
+
+[<Fact>]
+let ``acceptExitCodes should override exit codes in stage`` () =
+    let stage =
+        stage "" {
+            acceptExitCodes [| 4;5;6 |]
+        }
+
+    shouldNotBeCalled (fun _ ->
+        pipeline "" {
+            stage
+            runImmediate
+        }
+    )
+
+    let codes = stage.AcceptableExitCodes |> Seq.toArray
+    Assert.Equal<int array>([| 4;5;6 |], codes)

--- a/Fun.Build.Tests/PipelineBuilderTests.fs
+++ b/Fun.Build.Tests/PipelineBuilderTests.fs
@@ -7,7 +7,7 @@ open System.Threading.Tasks
 
 
 [<Fact>]
-let ``pipeline should world with mutiple stages with different conditions`` () =
+let ``pipeline should world with multiple stages with different conditions`` () =
     shouldNotBeCalled (fun call ->
         pipeline "" {
             stage "" {

--- a/Fun.Build.Tests/SequenceTests.fs
+++ b/Fun.Build.Tests/SequenceTests.fs
@@ -135,3 +135,35 @@ let ``nested stages should run in sequence`` () =
         runImmediate
     }
     Assert.Equal<int>([ 1; 2; 3; 4; 5; 6; 7 ], calls)
+
+[<Fact>]
+let ``custom exit code should pass for stage`` () =
+    pipeline "" {
+        stage "" {
+            acceptExitCodes [| 99 |]
+            run (fun _ -> async { return 99 })
+        }
+        runImmediate
+    }
+
+[<Fact>]
+let ``custom exit code should pass for pipeline`` () =
+    pipeline "" {
+        acceptExitCodes [| 99 |]
+        stage "" {
+            run (fun _ -> async { return 99 })
+        }
+        runImmediate
+    }
+
+[<Fact>]
+let ``custom exit code should pass for nested stage`` () =
+    pipeline "" {
+        stage "" {
+            acceptExitCodes [| 99 |]
+            stage "nested" {
+                run (fun _ -> async { return 99 })
+            }
+        }
+        runImmediate
+    }

--- a/Fun.Build/PipelineBuilder.fs
+++ b/Fun.Build/PipelineBuilder.fs
@@ -3,7 +3,6 @@ module Fun.Build.PipelineBuilder
 
 open System
 
-
 type PipelineBuilder(name: string) =
 
     member inline _.Run(_: unit) = ()
@@ -120,6 +119,16 @@ type PipelineBuilder(name: string) =
             }
         )
 
+    /// Override acceptable exit codes
+    [<CustomOperation("acceptExitCodes")>]
+    member inline _.acceptExitCodes([<InlineIfLambda>] build: BuildPipeline, codes: seq<int>) =
+        BuildPipeline(fun ctx ->
+            let ctx = build.Invoke ctx
+            { ctx with
+                AcceptableExitCodes = Set.ofSeq codes
+            }
+        )
+
     /// Reset command line args.
     /// By default, it will use Environment.GetCommandLineArgs()
     [<CustomOperation("cmdArgs")>]
@@ -129,7 +138,7 @@ type PipelineBuilder(name: string) =
             { ctx with CmdArgs = args }
         )
 
-    /// Set workding dir for all steps under the stage.
+    /// Set working dir for all steps under the stage.
     [<CustomOperation("workingDir")>]
     member inline _.workingDir([<InlineIfLambda>] build: BuildPipeline, dir: string) =
         BuildPipeline(fun ctx -> { build.Invoke ctx with WorkingDir = ValueSome dir })
@@ -148,7 +157,7 @@ type PipelineBuilder(name: string) =
     member _.runImmediate(build: BuildPipeline) = build.Invoke(PipelineContext.Create name).Run()
 
 
-    /// If set to true (default), then will check the if the CmdArgs contains -p if it append an arugment which is equal to the pipeline name, if all checks then it will run the pipeline.
+    /// If set to true (default), then will check the if the CmdArgs contains -p if it append an argument which is equal to the pipeline name, if all checks then it will run the pipeline.
     /// If set to false and if there is no -p in the CmdArgs, then it will also run the pipeline.
     [<CustomOperation("runIfOnlySpecified")>]
     member _.runIfOnlySpecified(build: BuildPipeline, ?specified: bool) =

--- a/Fun.Build/PipelineContextExtensions.fs
+++ b/Fun.Build/PipelineContextExtensions.fs
@@ -23,6 +23,7 @@ type PipelineContext with
             Name = name
             CmdArgs = Seq.toList (Environment.GetCommandLineArgs())
             EnvVars = envVars |> Seq.map (fun (KeyValue (k, v)) -> k, v) |> Map.ofSeq
+            AcceptableExitCodes = set [| 0 |]
             Timeout = ValueNone
             TimeoutForStep = ValueNone
             TimeoutForStage = ValueNone
@@ -65,7 +66,7 @@ type PipelineContext with
             if isActive then
                 let result, exns = stage.Run(StageIndex.Stage i, cancelToken)
                 stageExns.AddRange exns
-                hasError <- result <> 0 || hasError
+                hasError <- not (stage.IsAcceptableExitCode result) || hasError
             else
                 AnsiConsole.Write(Rule())
                 AnsiConsole.MarkupLine $"STAGE #{i} [bold grey]{stage.Name}[/] is inactive"

--- a/Fun.Build/StageBuilder.fs
+++ b/Fun.Build/StageBuilder.fs
@@ -70,7 +70,6 @@ type StageBuilder(name: string) =
             { ctx with Steps = ctx.Steps @ [ Step.StepOfStage(fn ()) ] }
         )
 
-
     /// Add or override environment variables
     [<CustomOperation("envVars")>]
     member inline _.envVars([<InlineIfLambda>] build: BuildStage, kvs: seq<string * string>) =
@@ -81,6 +80,16 @@ type StageBuilder(name: string) =
             }
         )
 
+    /// Override acceptable exit codes
+    [<CustomOperation("acceptExitCodes")>]
+    member inline _.acceptExitCodes([<InlineIfLambda>] build: BuildStage, codes: seq<int>) =
+        BuildStage(fun ctx ->
+            let ctx = build.Invoke ctx
+            { ctx with
+                AcceptableExitCodes = Set.ofSeq codes
+            }
+        )
+    
     /// Set timeout for every step under the current stage.
     /// Unit is second.
     [<CustomOperation("timeout")>]

--- a/Fun.Build/Types.fs
+++ b/Fun.Build/Types.fs
@@ -32,6 +32,7 @@ type StageContext = {
     TimeoutForStep: TimeSpan voption
     WorkingDir: string voption
     EnvVars: Map<string, string>
+    AcceptableExitCodes: Set<int>
     ParentContext: StageParent voption
     Steps: Step list
 }
@@ -41,6 +42,7 @@ type PipelineContext = {
     Name: string
     CmdArgs: string list
     EnvVars: Map<string, string>
+    AcceptableExitCodes: Set<int>
     Timeout: TimeSpan voption
     TimeoutForStep: TimeSpan voption
     TimeoutForStage: TimeSpan voption


### PR DESCRIPTION
A first attempt to solve #8. I'm not quite sure about the implementation so let me know if this needs any changes.

I noticed that you have a `run` command to format your code, but no local version is pinned to this repository. I can send another PR to install a local version and check the formatting in the CI.
Because in this PR I didn't format my code in order to keep the git diff as small as possible.
[More info](https://fsprojects.github.io/fantomas/docs/end-users/FormattingCheck.html).

Fixes #8.