### PR TITLE
Add a changelog file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### Added
+* Introduce [Keep a changelog](https://keepachangelog.com/)
+
+## [0.1.8] - 2022-09-28
+
+### Changed
+* Update FSharp.Core to 6.0.0

--- a/Fun.Build/Fun.Build.fsproj
+++ b/Fun.Build/Fun.Build.fsproj
@@ -5,7 +5,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TrimMode>link</TrimMode>
 		<IsTrimmable>true</IsTrimmable>
-		<Version>0.1.8</Version>
+		<ChangelogFile>../CHANGELOG.md</ChangelogFile>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -25,6 +25,7 @@
 
 	<ItemGroup>
 	  <PackageReference Update="FSharp.Core" Version="6.0.0" />
+	  <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" PrivateAssets="all" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
It would be nice if we could have a [changelog file](https://keepachangelog.com/en/1.0.0/) to see what changed between releases.

"Keep a changelog" is a very lightweight process where you can indicate what happened using a limited type of changes (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed` or `Security `).

The [Ionide.KeepAChangelog](https://github.com/ionide/KeepAChangelog) package will read this changelog file to determine the NuGet version.

If you don't want the version to bump just yet, you can use `Unreleased` header to already add the changelog entry instead.