### PR TITLE
Allow cmd to be marked as optional

### DIFF
--- a/Fun.Build.Tests/ConditionsBuilderTests.fs
+++ b/Fun.Build.Tests/ConditionsBuilderTests.fs
@@ -61,6 +61,19 @@ let ``whenCmd should work`` () =
         }
     )
 
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                whenCmd {
+                    name "test1"
+                    optional
+                }
+                run call
+            }
+            runImmediate
+        }
+    )
+
 
 [<Fact>]
 let ``whenCmdArg should work`` () =
@@ -85,6 +98,36 @@ let ``whenCmdArg should work`` () =
         }
     )
 
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                whenCmdArg "test1" "value" "description" true
+                run call
+            }
+            runImmediate
+        }
+    )
+
+    shouldNotBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                whenCmdArg "test1" "value" "description" false
+                run call
+            }
+            runImmediate
+        }
+    )
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            cmdArgs [ "test1"; "value" ]
+            stage "" {
+                whenCmdArg "test1" "value" "description" false
+                run call
+            }
+            runImmediate
+        }
+    )
 
 [<Fact>]
 let ``whenEnvVar should work`` () =

--- a/Fun.Build.Tests/PipelineBuilderTests.fs
+++ b/Fun.Build.Tests/PipelineBuilderTests.fs
@@ -351,3 +351,54 @@ let ``Should fail if stage is ignored`` () =
             runImmediate
         }
     )
+
+
+[<Fact>]
+let ``whenCmdArg should work`` () =
+    Assert.Throws<PipelineFailedException>(fun _ ->
+        shouldNotBeCalled (fun call ->
+            pipeline "" {
+                whenCmdArg "test1"
+                stage "" { run call }
+                runImmediate
+            }
+        )
+    )
+    |> ignore
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            cmdArgs [ "test1" ]
+            whenCmdArg "test1"
+            stage "" { run call }
+            runImmediate
+        }
+    )
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            whenCmdArg "test1" "value" "description" true
+            stage "" { run call }
+            runImmediate
+        }
+    )
+
+    Assert.Throws<PipelineFailedException>(fun _ ->
+        shouldNotBeCalled (fun call ->
+            pipeline "" {
+                whenCmdArg "test1" "value" "description" false
+                stage "" { run call }
+                runImmediate
+            }
+        )
+    )
+    |> ignore
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            cmdArgs [ "test1"; "value" ]
+            whenCmdArg "test1" "value" "description" false
+            stage "" { run call }
+            runImmediate
+        }
+    )

--- a/Fun.Build/Types.fs
+++ b/Fun.Build/Types.fs
@@ -31,9 +31,10 @@ type CmdArg =
         Name: CmdName
         Values: string list
         Description: string option
+        IsOptional: bool
     }
 
-    static member Create(?shortName: string, ?longName: string, ?description: string, ?values) = {
+    static member Create(?shortName: string, ?longName: string, ?description: string, ?values, ?isOptiomal: bool) = {
         Name =
             match shortName, longName with
             | Some s, Some l -> CmdName.FullName(s, l)
@@ -42,8 +43,10 @@ type CmdArg =
             | _ -> failwith "shortName or longName cannot be empty at the same time"
         Values = defaultArg values []
         Description = description
+        IsOptional = defaultArg isOptiomal false
     }
 
     member this.WithValue value = { this with Values = this.Values @ [ value ] }
     member this.WithValue values = { this with Values = this.Values @ values }
     member this.WithDescription x = { this with Description = Some x }
+    member this.WithOptional x = { this with IsOptional = x }

--- a/demo.fsx
+++ b/demo.fsx
@@ -140,6 +140,11 @@ pipeline "cmd-info" {
         // Description can also support multiple lines
         description "watch cool stuff \n dasd asdad \n asdasd as123"
     }
+    whenCmd {
+        name "--debug"
+        description "optional argument"
+        optional
+    }
     stage "condition demo" {
         noStdRedirectForStep
         failIfIgnored
@@ -176,5 +181,5 @@ pipeline "cmd-info" {
 
 
 // This will collect command line help information for you
-// You can run: dotnet demo.fsx -- -h
+// You can run: dotnet fsi demo.fsx -- -h
 tryPrintPipelineCommandHelp ()


### PR DESCRIPTION
Don't merge yet there is a decision to take about `whenAny`

Fix #41

@albertwoo Here is my proposition for the `optional` command.

If a command is marked as `optional` there is a visual indication in the help message:

![CleanShot 2023-08-30 at 21 59 19](https://github.com/slaveOftime/Fun.Build/assets/4760796/54e501a7-2fcc-4df8-b172-3f02add1825b)

About `whenAny` how should this be supported? Right now, I didn't add a version of `cmdArg` that support `isOptional`: `cmdArg "cmd" "value" "description" true`.

I suppose if `whenAny` supports `whenCmd` CE then we should add this overload to `cmdArg`.

Also, what happen if all the conditions in the `whenAny` are marked as optional and none are provided by the user? Should it succeed or should we fail and warn the user?