### PR TITLE
Finish optional command implementation

### DIFF
--- a/Fun.Build/ConditionsBuilder.fs
+++ b/Fun.Build/ConditionsBuilder.fs
@@ -255,6 +255,22 @@ type ConditionsBuilder() =
             ]
         )
 
+    [<CustomOperation("cmdArg")>]
+    member inline _.cmdArg
+        (
+            [<InlineIfLambda>] builder: BuildConditions,
+            argKeyLongName: string,
+            argValue: string,
+            description: string,
+            isOptional: bool
+        ) =
+        BuildConditions(fun conditions ->
+            builder.Invoke(conditions)
+            @ [
+                fun ctx -> ctx.WhenCmdArg(CmdName.LongName argKeyLongName, argValue, Some description, isOptional)
+            ]
+        )
+
 
     [<CustomOperation("branch")>]
     member inline _.branch([<InlineIfLambda>] builder: BuildConditions, branch: string) =


### PR DESCRIPTION
Related to PR #42

- Add variant of `cmdArg` that accept a `isOptional` argument
- Add tests to check the behaviour of using optional command inside of a `whenAny`
- Add tests to check the behaviour of using optional command inside of a `whenAll`