### PR TITLE
Conserve output format when possible

### DIFF
--- a/Fun.Build/BuiltinCmds.fs
+++ b/Fun.Build/BuiltinCmds.fs
@@ -34,8 +34,6 @@ module BuiltinCmdsInternal =
 
             ctx.BuildEnvVars() |> Map.iter (fun k v -> command.Environment[k] <- v)
 
-            command.StandardOutputEncoding <- Encoding.UTF8
-            command.RedirectStandardOutput <- true
             command
 
 

--- a/Fun.Build/ProcessExtensions.fs
+++ b/Fun.Build/ProcessExtensions.fs
@@ -7,6 +7,7 @@ open System.Diagnostics
 open System.Runtime.InteropServices
 open Spectre.Console
 open Fun.Build.Internal
+open System.Text
 
 type Process with
 
@@ -37,22 +38,40 @@ type Process with
 
 
     static member StartAsync(startInfo: ProcessStartInfo, commandLogString: string, logPrefix: string, ?printOutput, ?captureOutput) = async {
-        use result = Process.Start startInfo
-        let noPrefix = String.IsNullOrEmpty logPrefix
         let printOutput = defaultArg printOutput true
         let captureOutput = defaultArg captureOutput false
-        let shouldRedirectOutput = printOutput || captureOutput
+        let noPrefix = String.IsNullOrEmpty logPrefix
+        // We want to redirect output if
+        // 1. Use want to add prefix to the output
+        // 2. User asked to not print output
+        // 3. User asked to capture output
+        let shouldRedirectOutput = not noPrefix || not printOutput || captureOutput
+
+        // By default, we don't redirect output because redirecting the
+        // output lose the color information.
+        if shouldRedirectOutput then
+            // We redirect both standard output and error output
+            // because some process write mixed output to both...
+            // This should in theory avoid losing information because of the redirection.
+            startInfo.RedirectStandardOutput <- true
+            startInfo.RedirectStandardError <- true
+            startInfo.StandardOutputEncoding <- Encoding.UTF8
+            startInfo.StandardErrorEncoding <- Encoding.UTF8
+
+        use result = Process.Start startInfo
         let standardOutputSb = System.Text.StringBuilder()
 
+        let handleDataReceived (ev: DataReceivedEventArgs) =
+            if captureOutput then standardOutputSb.Append ev.Data |> ignore
+            if printOutput && not (String.IsNullOrEmpty ev.Data) then
+                if noPrefix then
+                    Console.WriteLine(ev.Data)
+                else
+                    Console.WriteLine(logPrefix + " " + ev.Data)
+
         if shouldRedirectOutput then
-            result.OutputDataReceived.Add(fun e ->
-                if captureOutput then standardOutputSb.Append e.Data |> ignore
-                if printOutput && not (String.IsNullOrEmpty e.Data) then
-                    if noPrefix then
-                        Console.WriteLine(e.Data)
-                    else
-                        Console.WriteLine(logPrefix + " " + e.Data)
-            )
+            result.OutputDataReceived.Add handleDataReceived
+            result.ErrorDataReceived.Add handleDataReceived
 
         use! cd =
             Async.OnCancel(fun _ ->


### PR DESCRIPTION
Fix #40

This PR implements the proposition from #40.

The idea is to not redirect the output if not required. This allows the spawned process to keep control of the formatting in the output.

This also allows the process to refresh / live update the console if that's how it works.

See how `RUNS` in yellow change to `PASS` in green in the video below.

https://github.com/slaveOftime/Fun.Build/assets/4760796/2fa71eda-53ff-47b1-b72b-08f2bf825c9f