### PR TITLE
Allow variable declaration inside `pipeline` and `stage`

### DIFF
--- a/Fun.Build.Tests/PipelineBuilderTests.fs
+++ b/Fun.Build.Tests/PipelineBuilderTests.fs
@@ -232,6 +232,27 @@ let ``Syntax check`` () =
     pipeline "" { stage1 } |> ignore
 
     pipeline "" {
+        let a = ""
+        let b = {| Test = "value" |}
+        runImmediate
+    }
+
+    pipeline "" {
+        let a = ""
+        let b = {| Test = "value" |}
+        runIfOnlySpecified
+    }
+
+    pipeline "" {
+        stage "" {
+            let a = ""
+            let b = {| Test = "value" |}
+            echo ""
+        }
+    }
+    |> ignore
+
+    pipeline "" {
         cmdArgs [ "" ]
         envVars [ "", "" ]
         stage1

--- a/Fun.Build/PipelineBuilder.fs
+++ b/Fun.Build/PipelineBuilder.fs
@@ -37,6 +37,8 @@ type PipelineBuilder(name: string) =
 
     member inline _.Yield(_: unit) = BuildPipeline id
 
+    member inline _.Yield(_: obj) = BuildPipeline id
+
     member inline _.Yield(stage: StageContext) = stage
 
 

--- a/Fun.Build/StageBuilder.fs
+++ b/Fun.Build/StageBuilder.fs
@@ -13,6 +13,7 @@ type StageBuilder(name: string) =
 
 
     member inline _.Yield(_: unit) = BuildStage id
+    member inline _.Yield(_: obj) = BuildStage id
     member inline _.Yield(stage: StageContext) = stage
 
     member inline _.Delay([<InlineIfLambda>] fn: unit -> BuildStage) = BuildStage(fun ctx -> fn().Invoke(ctx))


### PR DESCRIPTION
This is useful if you want have a lot of pipeline/stages and don't want to pollute the root module with variable that are useful only for a specific pipeline / stage.

```fs
pipeline "test-typescript" {

    let buildDir = "build/tests/TypeScript"

    stage "Pre tests"{
        run (fun _ ->
            if not <| Directory.Exists buildDir then
                Shell.cleanDir buildDir
        )
    }

    stage "Build" {
        echo $"Build project to {buildDir}"
    }

    runIfOnlySpecified
}
```