### PR TITLE
Add when' overload to accept a stage and treat stage result as a when condition for the enclosing context

### DIFF
--- a/Fun.Build.Tests/ConditionsBuilderTests.fs
+++ b/Fun.Build.Tests/ConditionsBuilderTests.fs
@@ -245,6 +245,19 @@ let ``when' stage should use stage execution result as when' condition for stage
     )
 
 [<Fact>]
+let ``when' stage should have parent context in execution mode`` () =
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            envVars [ "ENV", "0" ]
+            stage "" {
+                when' (stage "" {run (fun ctx -> ctx.GetEnvVar("ENV") |> int)})
+                run call
+            }
+            runImmediate
+        }
+    )
+
+[<Fact>]
 let ``when' stage should use stage execution result as when' condition for nested stage`` () =
     shouldNotBeCalled (fun call ->
         pipeline "" {

--- a/Fun.Build.Tests/ConditionsBuilderTests.fs
+++ b/Fun.Build.Tests/ConditionsBuilderTests.fs
@@ -223,6 +223,81 @@ let ``whenEnvVar should work`` () =
 
 
 [<Fact>]
+let ``when' stage should use stage execution result as when' condition for stage`` () =
+    shouldNotBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                when' (stage "" {run (fun ctx -> 1)})
+                run call
+            }
+            runImmediate
+        }
+    )
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                when' (stage "" {run (fun ctx -> 0)})
+                run call
+            }
+            runImmediate
+        }
+    )
+
+[<Fact>]
+let ``when' stage should use stage execution result as when' condition for nested stage`` () =
+    shouldNotBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                stage "nested" {
+                    when' (stage "" {run (fun ctx -> 1)})
+                    run call
+                }
+            }
+            runImmediate
+        }
+    )
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                stage "nested" {
+                    when' (stage "" {run (fun ctx -> 0)})
+                    run call
+                }
+            }
+            runImmediate
+        }
+    )
+
+[<Fact>]
+let ``when' stage should use stage execution result as when' condition in composed when`` () =
+    shouldNotBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                whenAll {
+                    when' (stage "" {run (fun ctx -> 1)})
+                }
+                run call
+            }
+            runImmediate
+        }
+    )
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            stage "" {
+                whenAll {
+                    when' (stage "" {run (fun ctx -> 0)})
+                }
+                run call
+            }
+            runImmediate
+        }
+    )
+
+
+[<Fact>]
 let ``whenAny should work`` () =
     let condition = whenAny {
         cmdArg "test1"

--- a/Fun.Build.Tests/PipelineBuilderTests.fs
+++ b/Fun.Build.Tests/PipelineBuilderTests.fs
@@ -330,10 +330,13 @@ let ``Verification should work`` () =
 
 [<Fact>]
 let ``when' stage should use stage execution result as verification condition for pipeline`` () =
+    let mutable numChecks = 0
     Assert.Throws<PipelineFailedException>(fun _ ->
         shouldNotBeCalled (fun call ->
             pipeline "" {
-                when' (stage "" {run (fun ctx -> 1)})
+                when' (stage "whenStageShouldFail" {run (fun ctx ->
+                    numChecks <- numChecks + 1
+                    1)})
                 stage "" {
                     run call
                 }
@@ -342,10 +345,11 @@ let ``when' stage should use stage execution result as verification condition fo
         )
     )
     |> ignore
+    Assert.Equal(1, numChecks)
 
     shouldBeCalled (fun call ->
         pipeline "" {
-            when' (stage "" {run (fun ctx -> 0)})
+            when' (stage "whenStageShouldPass" {run (fun ctx -> 0)})
             stage "" {
                 run call
             }

--- a/Fun.Build.Tests/PipelineBuilderTests.fs
+++ b/Fun.Build.Tests/PipelineBuilderTests.fs
@@ -328,6 +328,32 @@ let ``Verification should work`` () =
         }
     )
 
+[<Fact>]
+let ``when' stage should use stage execution result as verification condition for pipeline`` () =
+    Assert.Throws<PipelineFailedException>(fun _ ->
+        shouldNotBeCalled (fun call ->
+            pipeline "" {
+                when' (stage "" {run (fun ctx -> 1)})
+                stage "" {
+                    run call
+                }
+                runImmediate
+            }
+        )
+    )
+    |> ignore
+
+    shouldBeCalled (fun call ->
+        pipeline "" {
+            when' (stage "" {run (fun ctx -> 0)})
+            stage "" {
+                run call
+            }
+            runImmediate
+        }
+    )
+
+
 
 [<Fact>]
 let ``Should fail if stage is ignored`` () =

--- a/Fun.Build/ConditionsBuilder.fs
+++ b/Fun.Build/ConditionsBuilder.fs
@@ -32,6 +32,10 @@ module Internal =
                 false
             | Mode.Execution -> isTrue
 
+        member _.WhenStage(stage: StageContext) =
+            let result, exns = stage.Run(StageIndex.WhenStage, System.Threading.CancellationToken.None)
+            result
+
         member ctx.WhenEnvArg(info: EnvArg) =
             if info.Name |> String.IsNullOrEmpty then
                 failwith "ENV variable name cannot be empty"
@@ -212,6 +216,9 @@ type ConditionsBuilder() =
     [<CustomOperation("when'")>]
     member inline _.when'([<InlineIfLambda>] builder: BuildConditions, arg: bool) = buildConditions builder (fun ctx -> ctx.When'(arg))
 
+    [<CustomOperation("when'")>]
+    member inline _.when'([<InlineIfLambda>] build: BuildConditions, whenStage: StageContext) = buildConditions build (fun ctx -> ctx.WhenStage whenStage)
+
 
     [<CustomOperation("envVar")>]
     member inline _.envVar([<InlineIfLambda>] builder: BuildConditions, arg: EnvArg) = buildConditions builder (fun ctx -> ctx.WhenEnvArg(arg))
@@ -287,6 +294,9 @@ type StageBuilder with
     [<CustomOperation("when'")>]
     member inline _.when'([<InlineIfLambda>] build: BuildStage, value: bool) = buildStageIsActive build (fun ctx -> ctx.When' value)
 
+    // Set thage stage is active or should run depending on the results of the whenStage
+    [<CustomOperation("when'")>]
+    member inline _.when'([<InlineIfLambda>] build: BuildStage, whenStage: StageContext) = buildStageIsActive build (fun ctx -> ctx.WhenStage whenStage)
 
     /// Set if stage is active or should run by check the environment variable.
     [<CustomOperation("whenEnvVar")>]
@@ -368,6 +378,9 @@ type PipelineBuilder with
     [<CustomOperation("when'")>]
     member inline _.when'([<InlineIfLambda>] build: BuildPipeline, value: bool) = buildPipelineVerification build (fun ctx -> ctx.When' value)
 
+    // Set thage stage is active or should run depending on the results of the whenStage
+    [<CustomOperation("when'")>]
+    member inline _.when'([<InlineIfLambda>] build: BuildPipeline, whenStage: StageContext) = buildPipelineVerification build (fun ctx -> ctx.WhenStage whenStage)
 
     /// Set if pipeline can run by check the environment variable.
     [<CustomOperation("whenEnvVar")>]

--- a/Fun.Build/ConditionsBuilder.fs
+++ b/Fun.Build/ConditionsBuilder.fs
@@ -217,7 +217,7 @@ type ConditionsBuilder() =
     member inline _.when'([<InlineIfLambda>] builder: BuildConditions, arg: bool) = buildConditions builder (fun ctx -> ctx.When'(arg))
 
     [<CustomOperation("when'")>]
-    member inline _.when'([<InlineIfLambda>] build: BuildConditions, whenStage: StageContext) = buildConditions build (fun ctx -> ctx.WhenStage whenStage)
+    member inline _.when'([<InlineIfLambda>] builder: BuildConditions, whenStage: StageContext) = buildConditions builder (fun ctx -> ctx.WhenStage whenStage)
 
 
     [<CustomOperation("envVar")>]
@@ -294,7 +294,7 @@ type StageBuilder with
     [<CustomOperation("when'")>]
     member inline _.when'([<InlineIfLambda>] build: BuildStage, value: bool) = buildStageIsActive build (fun ctx -> ctx.When' value)
 
-    // Set thage stage is active or should run depending on the results of the whenStage
+    // Set if stage is active or should run depending on the results of the whenStage
     [<CustomOperation("when'")>]
     member inline _.when'([<InlineIfLambda>] build: BuildStage, whenStage: StageContext) = buildStageIsActive build (fun ctx -> ctx.WhenStage whenStage)
 
@@ -378,7 +378,7 @@ type PipelineBuilder with
     [<CustomOperation("when'")>]
     member inline _.when'([<InlineIfLambda>] build: BuildPipeline, value: bool) = buildPipelineVerification build (fun ctx -> ctx.When' value)
 
-    // Set thage stage is active or should run depending on the results of the whenStage
+    // Set if pipeline can run depending on the results of the whenStage
     [<CustomOperation("when'")>]
     member inline _.when'([<InlineIfLambda>] build: BuildPipeline, whenStage: StageContext) = buildPipelineVerification build (fun ctx -> ctx.WhenStage whenStage)
 

--- a/Fun.Build/ConditionsBuilder.fs
+++ b/Fun.Build/ConditionsBuilder.fs
@@ -32,9 +32,16 @@ module Internal =
                 false
             | Mode.Execution -> isTrue
 
-        member _.WhenStage(stage: StageContext) =
-            let result, exns = stage.Run(StageIndex.WhenStage, System.Threading.CancellationToken.None)
-            result
+        member ctx.WhenStage(stage: StageContext) =
+            match ctx.GetMode() with
+            | Mode.Execution ->
+                let result, exns = stage.Run(StageIndex.WhenStage, System.Threading.CancellationToken.None)
+                result
+            | Mode.Verification ->
+                AnsiConsole.MarkupLineInterpolated($"[yellow]? Check results of WHEN STAGE {stage.Name} above.[/]")
+                false
+            | _ ->
+                false
 
         member ctx.WhenEnvArg(info: EnvArg) =
             if info.Name |> String.IsNullOrEmpty then

--- a/Fun.Build/ConditionsBuilder.fs
+++ b/Fun.Build/ConditionsBuilder.fs
@@ -35,10 +35,12 @@ module Internal =
         member ctx.WhenStage(stage: StageContext) =
             match ctx.GetMode() with
             | Mode.Execution ->
-                let result, exns = stage.Run(StageIndex.WhenStage, System.Threading.CancellationToken.None)
+                let result, exns =
+                    { stage with ParentContext = ctx.ParentContext }
+                        .Run(StageIndex.Condition, System.Threading.CancellationToken.None)
                 result
             | Mode.Verification ->
-                AnsiConsole.MarkupLineInterpolated($"[yellow]? Check results of WHEN STAGE {stage.Name} above.[/]")
+                AnsiConsole.MarkupLineInterpolated($"[yellow]? [/]{ctx.BuildIndent().Substring(2)}check results of stage [yellow]{stage.Name}[/]")
                 false
             | _ ->
                 false

--- a/Fun.Build/StageContextExtensions.fs
+++ b/Fun.Build/StageContextExtensions.fs
@@ -205,8 +205,8 @@ module StageContextExtensionsInternal =
 
                     let extraInfo = $"timeout: {timeoutForStage}ms. step timeout: {timeoutForStep}ms."
                     match index with
-                    | StageIndex.WhenStage ->
-                        AnsiConsole.Write(Rule($"[grey50]WHEN STAGE [bold turquoise4]{namePath}[/] started. {extraInfo}[/]").LeftJustified())
+                    | StageIndex.Condition ->
+                        AnsiConsole.Write(Rule($"[grey50]CONDITION STAGE [bold turquoise4]{namePath}[/] started. {extraInfo}[/]").LeftJustified())
                     | StageIndex.Stage i ->
                         AnsiConsole.Write(Rule($"[grey50]STAGE #{i} [bold turquoise4]{namePath}[/] started. {extraInfo}[/]").LeftJustified())
                     | StageIndex.Step _ ->
@@ -346,9 +346,9 @@ module StageContextExtensionsInternal =
 
                     let color = if isSuccess then "turquoise4" else "red"
                     match index with
-                    | StageIndex.WhenStage ->
+                    | StageIndex.Condition ->
                         AnsiConsole.Write(
-                            Rule($"""[grey50]WHEN STAGE [bold {color}]{namePath}[/] finished. {stageSW.ElapsedMilliseconds}ms.[/]""")
+                            Rule($"""[grey50]CONDITION STAGE [bold {color}]{namePath}[/] finished. {stageSW.ElapsedMilliseconds}ms.[/]""")
                                 .LeftJustified()
                         )
                     | StageIndex.Stage i ->
@@ -367,7 +367,7 @@ module StageContextExtensionsInternal =
                     AnsiConsole.WriteLine()
 
                     match index with
-                    | StageIndex.WhenStage -> AnsiConsole.Write(Rule($"[grey50]WHEN STAGE {namePath} is [yellow]inactive[/][/]").LeftJustified())
+                    | StageIndex.Condition -> AnsiConsole.Write(Rule($"[grey50]CONDITION STAGE {namePath} is [yellow]inactive[/][/]").LeftJustified())
                     | StageIndex.Stage i -> AnsiConsole.Write(Rule($"[grey50]STAGE #{i} {namePath} is [yellow]inactive[/][/]").LeftJustified())
                     | StageIndex.Step _ ->
                         AnsiConsole.MarkupLineInterpolated($"[grey50]{stage.BuildCurrentStepPrefix()}> sub-stage is [yellow]inactive[/][/]")

--- a/Fun.Build/StageContextExtensions.fs
+++ b/Fun.Build/StageContextExtensions.fs
@@ -205,6 +205,8 @@ module StageContextExtensionsInternal =
 
                     let extraInfo = $"timeout: {timeoutForStage}ms. step timeout: {timeoutForStep}ms."
                     match index with
+                    | StageIndex.WhenStage ->
+                        AnsiConsole.Write(Rule($"[grey50]WHEN STAGE [bold turquoise4]{namePath}[/] started. {extraInfo}[/]").LeftJustified())
                     | StageIndex.Stage i ->
                         AnsiConsole.Write(Rule($"[grey50]STAGE #{i} [bold turquoise4]{namePath}[/] started. {extraInfo}[/]").LeftJustified())
                     | StageIndex.Step _ ->
@@ -230,6 +232,7 @@ module StageContextExtensionsInternal =
                                             ParentContext = ValueSome(StageParent.Stage stage)
                                         }
                                     subStage.BuildCurrentStepPrefix() + ">"
+  
 
                             let exns = ResizeArray<Exception>()
                             try
@@ -343,6 +346,11 @@ module StageContextExtensionsInternal =
 
                     let color = if isSuccess then "turquoise4" else "red"
                     match index with
+                    | StageIndex.WhenStage ->
+                        AnsiConsole.Write(
+                            Rule($"""[grey50]WHEN STAGE [bold {color}]{namePath}[/] finished. {stageSW.ElapsedMilliseconds}ms.[/]""")
+                                .LeftJustified()
+                        )
                     | StageIndex.Stage i ->
                         AnsiConsole.Write(
                             Rule($"""[grey50]STAGE #{i} [bold {color}]{namePath}[/] finished. {stageSW.ElapsedMilliseconds}ms.[/]""")
@@ -359,6 +367,7 @@ module StageContextExtensionsInternal =
                     AnsiConsole.WriteLine()
 
                     match index with
+                    | StageIndex.WhenStage -> AnsiConsole.Write(Rule($"[grey50]WHEN STAGE {namePath} is [yellow]inactive[/][/]").LeftJustified())
                     | StageIndex.Stage i -> AnsiConsole.Write(Rule($"[grey50]STAGE #{i} {namePath} is [yellow]inactive[/][/]").LeftJustified())
                     | StageIndex.Step _ ->
                         AnsiConsole.MarkupLineInterpolated($"[grey50]{stage.BuildCurrentStepPrefix()}> sub-stage is [yellow]inactive[/][/]")

--- a/Fun.Build/Types.Internal.fs
+++ b/Fun.Build/Types.Internal.fs
@@ -29,6 +29,7 @@ type StageParent =
 type StageIndex =
     | Step of step: int
     | Stage of stage: int
+    | WhenStage
 
 
 type CommandHelpContext = {

--- a/Fun.Build/Types.Internal.fs
+++ b/Fun.Build/Types.Internal.fs
@@ -29,7 +29,7 @@ type StageParent =
 type StageIndex =
     | Step of step: int
     | Stage of stage: int
-    | WhenStage
+    | Condition
 
 
 type CommandHelpContext = {

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ pipeline "Fun.Build" {
             cmdArg "cmdKey" "" "Check has cmd arg"
             cmdArg "cmdKey" "cmdValue" "Check has cmd arg value which should be behind the cmdKey"
             whenNot { cmdArg "--not-demo" }
+            when' (stage "Check" {run (fun ctx -> Ok())}) // Check result of a stage, useful for dynamic checks
         }
         shuffleExecuteSequence // It can shuffle the sequence of steps executing sequence
         run "dotnet --version"

--- a/demo.fsx
+++ b/demo.fsx
@@ -63,6 +63,7 @@ pipeline "Fun.Build" {
             cmdArg "cmdKey" "" "Check has cmd arg"
             cmdArg "cmdKey" "cmdValue" "Check has cmd arg value which should be behind the cmdKey"
             whenNot { cmdArg "--not-demo" }
+            when' (stage "Check" {run (fun ctx -> Ok())}) // Check result of a stage, useful for dynamic checks
         }
         shuffleExecuteSequence // It can shuffle the sequence of steps executing sequence
         run "dotnet --version"


### PR DESCRIPTION
Feedback welcome as this is my first engagement with this codebase.

Closes #75 

Some concerns I have:

#### `CancellationToken.None` 

As we need to run the stage during the condition evaluation of `IsActive` we don't have a cancellation token, so these whenStages aren't running as part of the normal execution model.

Is this an issue for you?  If so, we might need to update the IsActive signature to accept a cancellation token.

#### Logging Output

Most of the logging logic makes a lot of assumptions about when in the execution it's being called.  I've added a new `StageIndex` called `WhenStage` which allows us to log without an index.  The logging result looks like:

For a pipeline when the when stage fails:
```
Run PIPELINE . Total timeout: -1ms.

Run stages

── WHEN STAGE  started. timeout: -1ms. step timeout: -1ms. ───────────────────────────────────────────────────────────────────────────────────────────────────────

/step-0> started
Error: Exit code is not indicating as successful.
/step-0> finished. 0ms. will trigger canncellation.
── WHEN STAGE  finished. 0ms. ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


── STAGE #0  is inactive ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Run stages finished


Run post stages
Run post stages finished


PIPELINE  is finished in 1 ms
```

For a pipeline where the whenStage passes:
```
Run PIPELINE . Total timeout: -1ms.

Run stages

── WHEN STAGE  started. timeout: -1ms. step timeout: -1ms. ───────────────────────────────────────────────────────────────────────────────────────────────────────

/step-0> started
/step-0> finished. 0ms. 

── WHEN STAGE  finished. 0ms. ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


── STAGE #0  started. timeout: -1ms. step timeout: -1ms. ─────────────────────────────────────────────────────────────────────────────────────────────────────────

/step-0> started
/step-0> finished. 0ms. 

── STAGE #0  finished. 0ms. ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Run stages finished


Run post stages
Run post stages finished


PIPELINE  is finished in 1 ms
```

When the `when'` is used at the pipeline level, the logging occurs BEFORE the `Run PIPELINE` message:

```
── WHEN STAGE whenStageShouldPass started. timeout: -1ms. step timeout: -1ms. ────────────────────────────────────────────────────────────────────────────────────

whenStageShouldPass/step-0> started
whenStageShouldPass/step-0> finished. 0ms. 

── WHEN STAGE whenStageShouldPass finished. 0ms. ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Run PIPELINE . Total timeout: -1ms.

Run stages

── STAGE #0  started. timeout: -1ms. step timeout: -1ms. ─────────────────────────────────────────────────────────────────────────────────────────────────────────

/step-0> started
/step-0> finished. 0ms. 

── STAGE #0  finished. 0ms. ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Run stages finished


Run post stages
Run post stages finished


PIPELINE  is finished in 1 ms
```

When the condition fails, this is especially odd as it shows the logs, then indicates that the verification failed and shows the conditions that failed, but it doesn't have access to the results of when the whenStage was first run, so I've updated the logs to refer back to the WHEN STAGE logs - the `?` is because other conditions will show with green ticks and red crosses, as their results are static:

![image](https://github.com/user-attachments/assets/65fc7f87-8b2e-404e-93d9-723b97f03176)


Is this ok? If there are multiple `when` stage` calls it might be a bit confusing, but hopefully the user knows to name the condition.

