### PR TITLE
feat: add support for remaining args

### DIFF
--- a/Fun.Build.Tests/PipelineBuilderTests.fs
+++ b/Fun.Build.Tests/PipelineBuilderTests.fs
@@ -485,3 +485,61 @@ let ``runBeforeEachStage and runAfterEachStage should work`` () =
     Assert.Equal(4, j)
     Assert.Equal(3, ti)
     Assert.Equal(3, tj)
+
+[<Fact>]
+let ``check GetAllCmdArgs and RemainingArgs works when remaining args is not empty`` () =
+    let mutable actualAllCmdArgs = []
+    let mutable actualRemainingArgs = []
+
+    pipeline "demo" {
+        cmdArgs [ "-p"; "demo"; "test1"; "v1"; "--"; "test2"; "v2" ]
+        stage "shows arguments" {
+            run (fun ctx ->
+                actualAllCmdArgs <- ctx.GetAllCmdArgs()
+                actualRemainingArgs <- ctx.GetRemainingCmdArgs()
+            )
+        }
+        runImmediate
+    }
+
+    Assert.Equal<string list>([ "-p"; "demo"; "test1"; "v1" ], actualAllCmdArgs)
+    Assert.Equal<string list>([ "test2"; "v2" ], actualRemainingArgs)
+
+[<Fact>]
+let ``check GetAllCmdArgs and RemainingArgs works when remaining args is provided but empty`` () =
+    let mutable actualAllCmdArgs = []
+    let mutable actualRemainingArgs = []
+
+    pipeline "demo" {
+        cmdArgs [ "-p"; "demo"; "test1"; "v1"; "--" ]
+        stage "shows arguments" {
+            run (fun ctx ->
+                actualAllCmdArgs <- ctx.GetAllCmdArgs()
+                actualRemainingArgs <- ctx.GetRemainingCmdArgs()
+            )
+        }
+        runImmediate
+    }
+
+    Assert.Equal<string list>([ "-p"; "demo"; "test1"; "v1" ], actualAllCmdArgs)
+    Assert.Equal<string list>([], actualRemainingArgs)
+
+
+[<Fact>]
+let ``check GetAllCmdArgs and RemainingArgs works when remaining args is not provided`` () =
+    let mutable actualAllCmdArgs = []
+    let mutable actualRemainingArgs = []
+
+    pipeline "demo" {
+        cmdArgs [ "-p"; "demo"; "test1"; "v1" ]
+        stage "shows arguments" {
+            run (fun ctx ->
+                actualAllCmdArgs <- ctx.GetAllCmdArgs()
+                actualRemainingArgs <- ctx.GetRemainingCmdArgs()
+            )
+        }
+        runImmediate
+    }
+
+    Assert.Equal<string list>([ "-p"; "demo"; "test1"; "v1" ], actualAllCmdArgs)
+    Assert.Equal<string list>([], actualRemainingArgs)

--- a/Fun.Build/PipelineBuilder.fs
+++ b/Fun.Build/PipelineBuilder.fs
@@ -177,7 +177,13 @@ type PipelineBuilder(name: string) =
     member inline _.cmdArgs([<InlineIfLambda>] build: BuildPipeline, args: string list) =
         BuildPipeline(fun ctx ->
             let ctx = build.Invoke ctx
-            { ctx with CmdArgs = args }
+
+            let argsInfo = resolveCmdArgsAndRemainings args
+
+            { ctx with
+                CmdArgs = argsInfo.CmdArgs
+                RemainingCmdArgs = argsInfo.RemainingArgs
+            }
         )
 
     /// Set working dir for all steps under the stage.

--- a/Fun.Build/PipelineContextExtensions.fs
+++ b/Fun.Build/PipelineContextExtensions.fs
@@ -22,12 +22,15 @@ module PipelineContextExtensionsInternal =
                 with _ ->
                     envVars.Add(key, "")
 
+            let argsInfo = Environment.GetCommandLineArgs() |> Array.toList |> resolveCmdArgsAndRemainings
+
             {
                 Name = name
                 Description = ValueNone
                 Mode = Mode.Execution
                 Verify = fun _ -> true
-                CmdArgs = Seq.toList (Environment.GetCommandLineArgs())
+                CmdArgs = argsInfo.CmdArgs
+                RemainingCmdArgs = argsInfo.RemainingArgs
                 EnvVars = envVars |> Seq.map (fun (KeyValue(k, v)) -> k, v) |> Map.ofSeq
                 AcceptableExitCodes = set [| 0 |]
                 Timeout = ValueNone

--- a/Fun.Build/StageContextExtensions.fs
+++ b/Fun.Build/StageContextExtensions.fs
@@ -493,10 +493,38 @@ module StageContextExtensions =
         // If not find then return ""
         member inline ctx.GetEnvVar(key: string) = ctx.TryGetEnvVar key |> ValueOption.defaultValue ""
 
+        /// <summary>
+        /// Get the command arguments from the command line without the remaining arguments that are placed after <c>--</c>.
+        ///
+        /// For example, if you run the following arguments:
+        ///
+        /// <c> -p demo test1 v1 -- test2 v2</c>
+        ///
+        /// will return
+        ///
+        /// <c>[ "-p"; "demo"; "test1"; "v1" ]</c>
+        /// </summary>
         member ctx.GetAllCmdArgs() =
             match ctx.ParentContext with
             | ValueSome(StageParent.Pipeline p) -> p.CmdArgs
             | ValueSome(StageParent.Stage s) -> s.GetAllCmdArgs()
+            | ValueNone -> []
+
+        /// <summary>
+        /// Return the remaining command arguments they are the arguments placed after <c>--</c> in the command line.
+        ///
+        /// For example, if you run the following arguments:
+        ///
+        /// <c> -p demo test1 v1 -- test2 v2</c>
+        ///
+        /// will return
+        ///
+        /// <c>[ "test2"; "v2" ]</c>
+        /// </summary>
+        member ctx.GetRemainingCmdArgs() =
+            match ctx.ParentContext with
+            | ValueSome(StageParent.Pipeline p) -> p.RemainingCmdArgs
+            | ValueSome(StageParent.Stage s) -> s.GetRemainingCmdArgs()
             | ValueNone -> []
 
         member ctx.TryGetCmdArg(key: string) =

--- a/Fun.Build/Types.Internal.fs
+++ b/Fun.Build/Types.Internal.fs
@@ -76,6 +76,7 @@ type PipelineContext = {
     /// Verify before run pipeline, will throw PipelineFailedException if return false
     Verify: PipelineContext -> bool
     CmdArgs: string list
+    RemainingCmdArgs: string list
     EnvVars: Map<string, string>
     AcceptableExitCodes: Set<int>
     Timeout: TimeSpan voption

--- a/Fun.Build/Utils.fs
+++ b/Fun.Build/Utils.fs
@@ -74,6 +74,19 @@ let getFsiFileName () =
     else
         "your_script.fsx"
 
+let resolveCmdArgsAndRemainings (args: string list) =
+
+    let cmdArgs = args |> List.takeWhile (fun x -> x <> "--")
+
+    let remainingArgs =
+        let remainingArgsStartIndex = cmdArgs.Length + 1
+
+        if remainingArgsStartIndex < args.Length then
+            args.[remainingArgsStartIndex..]
+        else
+            []
+
+    {| CmdArgs = cmdArgs; RemainingArgs = remainingArgs |}
 
 module ValueOption =
 


### PR DESCRIPTION
I don't know how to make this change testable because it happens at the creation of the `Pipeline` so I added a demo script to showcase what it does and as an easy way to check that all is good for you.

One idea for making it testable was to change:

https://github.com/slaveOftime/Fun.Build/blob/3053b5eb9fa259ae5d6a454e6b2aa375fbb2544f/Fun.Build/PipelineContextExtensions.fs#L13-L15

to 

```fs
PipelineContext with 
  
     static member Create(name: string, ?forceArgs : string array) =
```

but I don't think this is good idea to change an API just to make it testable. Because I don't think we ever want to override the `Environment.GetCommandLineArgs()` in a normal usage.
